### PR TITLE
Fix infinite-stuck when 'Merged results pipelines' is enabled

### DIFF
--- a/server/src/MergeRequestAcceptor.ts
+++ b/server/src/MergeRequestAcceptor.ts
@@ -327,21 +327,6 @@ export const acceptMergeRequest = async (
 		};
 	}
 
-	if (
-		mergeRequestInfo.head_pipeline !== null &&
-		mergeRequestInfo.sha !== mergeRequestInfo.head_pipeline.sha
-	) {
-		console.log(
-			`[MR][${mergeRequestInfo.iid}] detecting old pipeline as head. Marking as PipelineInProgress`,
-		);
-		return {
-			kind: AcceptMergeRequestResultKind.PipelineInProgress,
-			mergeRequestInfo,
-			user,
-			pipeline: mergeRequestInfo.head_pipeline,
-		};
-	}
-
 	// the latest pipeline is incomplete / has failed
 	if (
 		mergeRequestInfo.head_pipeline !== null &&


### PR DESCRIPTION
When [merged results pipeline](https://docs.gitlab.com/ee/ci/pipelines/merged_results_pipelines.html) is enabled on the repository, the `head_pipeline.sha` is the merge commit with target branch, not the actual latest commit, so it mismatches.

Looking at the API docs ([get single MR](https://docs.gitlab.com/ee/api/merge_requests.html#get-single-mr), [get single pipeline](https://docs.gitlab.com/ee/api/pipelines.html#get-a-single-pipeline)), it is probably not possible to retrieve if the pipeline is in the "merged result" mode or not.