### PR TITLE
Config: ensure GITLAB_URL does not end with /

### DIFF
--- a/server/src/Config.ts
+++ b/server/src/Config.ts
@@ -39,7 +39,7 @@ export const defaultConfig: Config = {
 };
 
 export const getConfig = (): Config => ({
-	GITLAB_URL: env.get('GITLAB_URL').default(defaultConfig.GITLAB_URL).asUrlString(),
+	GITLAB_URL: env.get('GITLAB_URL').default(defaultConfig.GITLAB_URL).asUrlString().replace(/\/$/g, ''),
 	GITLAB_AUTH_TOKEN: env.get('GITLAB_AUTH_TOKEN').required().asString(),
 	CI_CHECK_INTERVAL:
 		env.get('CI_CHECK_INTERVAL').default(`${defaultConfig.CI_CHECK_INTERVAL}`).asIntPositive() *


### PR DESCRIPTION
Looks like since GitLab 16.10 cannot handle doubled `//` anymore

![image](https://github.com/pepakriz/gitlab-merger-bot/assets/1993453/a995a40f-085a-4a7a-a6e0-203dee076b2e)
